### PR TITLE
Display the values of time statistics with two decimal places of precision

### DIFF
--- a/components/StatisticDisplay.tsx
+++ b/components/StatisticDisplay.tsx
@@ -9,7 +9,7 @@ const StatisticDisplay: React.FC<Props> = (props) => {
     // some assumptions to make for now
     if (props.stat[0].endsWith('_time')) {
         return <>
-            {!props.no_adjust ? Math.round(props.stat[1] / 20) : Math.round(props.stat[1])}s
+            {(!props.no_adjust ? props.stat[1] / 20 : props.stat[1]).toFixed(2)}s
         </>
     }
 


### PR DESCRIPTION
![Withersweeper quickest time leaderboard](https://user-images.githubusercontent.com/24855774/149607149-09eae86d-0ed7-4d2e-b0ef-fe9382eddb05.png)